### PR TITLE
Fix highlighting of JSON `null`

### DIFF
--- a/grammars/json.yaml-tmLanguage
+++ b/grammars/json.yaml-tmLanguage
@@ -88,7 +88,7 @@ repository:
     match: '(?<=^|[,:\s\[])(true|false)(?=$|[,\s\]])'
 
   # Null
-  null:
+  'null':
     name: constant.language.null.json
     match: '(?<=^|[,:\s\[])null(?=$|[,\s\]])'
 


### PR DESCRIPTION
## Description
This PR fixes the highlighting of `null` values in JSON files, which are currently highlighted as illegal/unexpected syntax:

#### [Before][]

<img src="https://user-images.githubusercontent.com/2346707/139949273-76df177b-526c-46ae-a4b9-d9f797974c37.png" alt="Figure 1: Before" width="442" />

#### [After][]

<img src="https://user-images.githubusercontent.com/2346707/139949589-fdb57219-e745-4932-b2b4-48e901aa33cc.png" alt="Figure 2: After" width="442" />

[Before]: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=source.json&grammar_format=auto&grammar_url=&grammar_text=&code_source=from-text&code_url=&code=%7B%0D%0A%09%22example%22%3A+null%0D%0A%7D
[After]: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=yaml&grammar_url=https%3A%2F%2Fgithub.com%2FCutlery-Drawer%2FNovaGrammars%2Fblob%2Fee65f89256f9d7cc95c17fb8cce3a8c6cab623b5%2Fgrammars%2Fjson.yaml-tmLanguage&grammar_text=&code_source=from-text&code_url=&code=%7B%0D%0A%09%22example%22%3A+null%0D%0A%7D