### PR TITLE
Polish and rename `.git-blame-ignore-revs` grammar

### DIFF
--- a/grammars/git-blame-ignore-revs.yaml-tmLanguage
+++ b/grammars/git-blame-ignore-revs.yaml-tmLanguage
@@ -20,7 +20,7 @@ repository:
 
   sha:
     name: constant.numeric.sha.git-blame-ignore
-    match: '^[0-9a-fA-F]{40}$'
+    match: '[0-9a-fA-F]{40}(?=\s*$)'
 
   invalid:
     name: invalid.illegal.git-blame-ignore

--- a/grammars/git-blame-ignore-revs.yaml-tmLanguage
+++ b/grammars/git-blame-ignore-revs.yaml-tmLanguage
@@ -24,4 +24,4 @@ repository:
 
   invalid:
     name: invalid.illegal.git-blame-ignore
-    match: '\S+'
+    match: '\S.*?(?=\s*$)'

--- a/grammars/git-revlist.yaml-tmLanguage
+++ b/grammars/git-revlist.yaml-tmLanguage
@@ -11,7 +11,7 @@ repository:
     - include: '#invalid'
 
   comment:
-    name: comment.line.git-revlist
+    name: comment.line.number-sign.git-revlist
     begin: '#'
     end: '$'
     beginCaptures:

--- a/grammars/git-revlist.yaml-tmLanguage
+++ b/grammars/git-revlist.yaml-tmLanguage
@@ -1,5 +1,8 @@
 name: Git Revision List
 scopeName: source.git-revlist
+fileTypes:
+-  git-blame-ignore-revs
+- .git-blame-ignore-revs
 patterns:
 - include: '#main'
 

--- a/grammars/git-revlist.yaml-tmLanguage
+++ b/grammars/git-revlist.yaml-tmLanguage
@@ -1,5 +1,5 @@
-name: Git Blame Ignore Revs
-scopeName: source.git-blame-ignore
+name: Git Revision List
+scopeName: source.git-revlist
 patterns:
 - include: '#main'
 
@@ -11,17 +11,17 @@ repository:
     - include: '#invalid'
 
   comment:
-    name: comment.line.git-blame-ignore
+    name: comment.line.git-revlist
     begin: '#'
     end: '$'
     beginCaptures:
       '0':
-        name: punctuation.definition.comment.git-blame-ignore
+        name: punctuation.definition.comment.git-revlist
 
   sha:
-    name: constant.numeric.sha.git-blame-ignore
+    name: constant.numeric.sha.git-revlist
     match: '[0-9a-fA-F]{40}(?=\s*$)'
 
   invalid:
-    name: invalid.illegal.git-blame-ignore
+    name: invalid.illegal.git-revlist
     match: '\S.*?(?=\s*$)'

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ This repository contains various syntax highlighting/grammar files that I have c
 - **WhiteSpace**: [grammar](/grammars/whitespace.yaml-tmLanguage), [sample](/samples/whitespace.ws), [preview][whitespace-preview]
 - **Win32 Messages File**: [grammar](/grammars/win32-messages.yaml-tmLanguage), [sample](/samples/messages.mc), [preview][win32-preview]
 - **Generic Hash-Commented**: [grammar](/grammars/hash-commented.yaml-tmLanguage), [sample](/samples/.git-blame-ignore-revs), [preview][hash-commented-preview]
-- **Git Blame Ignore Revs**: [grammar](/grammars/git-blame-ignore-revs.yaml-tmLanguage), [sample](/samples/.git-blame-ignore-revs), [preview][blame-ignore-preview]
+- **Git Revision List**: [grammar](/grammars/git-revlist.yaml-tmLanguage), [sample](/samples/.git-blame-ignore-revs), [preview][blame-ignore-preview]
 
 ### External
 Grammars created by me that are found in other repositories.
@@ -29,6 +29,6 @@ Grammars created by me that are found in other repositories.
 [whitespace-preview]: https://nixinova.github.io/NovaLightshow/?grammar-type=url&grammar=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/grammars/whitespace.yaml-tmLanguage&sample-type=url&sample=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/samples/whitespace.ws
 [win32-preview]: https://nixinova.github.io/NovaLightshow/?grammar-type=url&grammar=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/grammars/win32-messages.yaml-tmLanguage&sample-type=url&sample=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/samples/messages.mc
 [hash-commented-preview]: https://nixinova.github.io/NovaLightshow/?grammar-type=url&grammar=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/grammars/hash-commented.yaml-tmLanguage&sample-type=url&sample=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/samples/.git-blame-ignore-revs
-[blame-ignore-preview]: https://nixinova.github.io/NovaLightshow/?grammar-type=url&grammar=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/grammars/git-blame-ignore-revs.yaml-tmLanguage&sample-type=url&sample=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/samples/.git-blame-ignore-revs
+[blame-ignore-preview]: https://nixinova.github.io/NovaLightshow/?grammar-type=url&grammar=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/grammars/git-revlist.yaml-tmLanguage&sample-type=url&sample=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/samples/.git-blame-ignore-revs
 [novasheets-preview]: https://nixinova.github.io/NovaLightshow/?grammar-type=url&grammar=https://github.com/NovaSheets/vscode/blob/main/grammars/novasheets.tmLanguage.yaml&sample-type=url&sample=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/samples/novasheets.nvss
 [astro-preview]: https://nixinova.github.io/NovaLightshow/?grammar-type=url&grammar=https://github.com/Nixinova/Astro-vscode/blob/main/grammars/astro.tmLanguage.yaml&sample-type=url&sample=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/samples/index.astro

--- a/samples/.git-blame-ignore-revs
+++ b/samples/.git-blame-ignore-revs
@@ -1,11 +1,16 @@
-# git-blame ignored revisions
-# To configure, run
-#   git config blame.ignoreRevsFile .git-blame-ignore-revs
-# Requires Git > 2.23
-# See https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
+# 40-digit checksum (valid)
+1d92f4f73ed125bcd6912ae3ec804e405f4076a2
 
-# Apply prettier
-5180ecdca48e486b4b0f347fcbd752f865df5e55
+# 41-digit checksum (invalid)
+1d92f4f73ed125bcd6912ae3ec804e405f4076a20
 
-# Update prettier
-41085248560b1403b8d0f99f108491e679531c6c
+Invalid line with whitespace
+
+
+	# Indented, 40-digit checksum (valid)
+	1d92f4f73ed125bcd6912ae3ec804e405f4076a2
+
+	# Indented, 41-digit checksum (invalid)
+	1d92f4f73ed125bcd6912ae3ec804e405f4076a20
+
+   Indented, invalid line with whitespace   


### PR DESCRIPTION
This pull-request combines the following changes in the support of github/linguist#5903:

1.	**Grammar renamed to be more context-agnostic.**[^1]
2.	**Revision IDs with leading or trailing whitespace are now highlighted correctly.**
3.	**Invalid lines containing whitespace now yield nicer-looking highlighting.**

[^1]: I [explained](https://github.com/github/linguist/pull/5903/files#r878683609) the rationale for this in my original review, but if you feel strongly about keeping the current name for some reason, you can revert ed99b26 specifically.

**Preview:** [Before](https://novalightshow.netlify.app/?grammar-type=url&grammar=https%3A%2F%2Fraw.githubusercontent.com%2FNixinova%2FNovaGrammars%2F1d92f4f73ed125bcd6912ae3ec804e405f4076a2%2Fgrammars%2Fgit-blame-ignore-revs.yaml-tmLanguage&sample-type=text&sample=%23+40-digit+checksum+%28valid%29%0A1d92f4f73ed125bcd6912ae3ec804e405f4076a2%0A%0A%23+41-digit+checksum+%28invalid%29%0A1d92f4f73ed125bcd6912ae3ec804e405f4076a20%0A%0AInvalid+line+with+whitespace%0A%0A%0A%09%23+Indented%2C+40-digit+checksum+%28valid%29%0A%091d92f4f73ed125bcd6912ae3ec804e405f4076a2%0A%0A%09%23+Indented%2C+41-digit+checksum+%28invalid%29%0A%091d92f4f73ed125bcd6912ae3ec804e405f4076a20%0A%0A+++Indented%2C+invalid+line+with+whitespace+++%0A) | [After](https://novalightshow.netlify.app/?grammar-type=text&grammar=name%3A+Git+Revision+List%0AscopeName%3A+source.git-revlist%0Apatterns%3A%0A-+include%3A+%27%23main%27%0A%0Arepository%3A%0A++main%3A%0A++++patterns%3A%0A++++-+include%3A+%27%23comment%27%0A++++-+include%3A+%27%23sha%27%0A++++-+include%3A+%27%23invalid%27%0A%0A++comment%3A%0A++++name%3A+comment.line.git-revlist%0A++++begin%3A+%27%23%27%0A++++end%3A+%27%24%27%0A++++beginCaptures%3A%0A++++++%270%27%3A%0A++++++++name%3A+punctuation.definition.comment.git-revlist%0A%0A++sha%3A%0A++++name%3A+constant.numeric.sha.git-revlist%0A++++match%3A+%27%5B0-9a-fA-F%5D%7B40%7D%28%3F%3D%5Cs*%24%29%27%0A%0A++invalid%3A%0A++++name%3A+invalid.illegal.git-revlist%0A++++match%3A+%27%5CS.*%3F%28%3F%3D%5Cs*%24%29%27%0A&sample-type=text&sample=%23+40-digit+checksum+%28valid%29%0A1d92f4f73ed125bcd6912ae3ec804e405f4076a2%0A%0A%23+41-digit+checksum+%28invalid%29%0A1d92f4f73ed125bcd6912ae3ec804e405f4076a20%0A%0AInvalid+line+with+whitespace%0A%0A%0A%09%23+Indented%2C+40-digit+checksum+%28valid%29%0A%091d92f4f73ed125bcd6912ae3ec804e405f4076a2%0A%0A%09%23+Indented%2C+41-digit+checksum+%28invalid%29%0A%091d92f4f73ed125bcd6912ae3ec804e405f4076a20%0A%0A+++Indented%2C+invalid+line+with+whitespace+++%0A)