### PR TITLE
Fix JSON values before `}` being highlighted as invalid

### DIFF
--- a/grammars/json.yaml-tmLanguage
+++ b/grammars/json.yaml-tmLanguage
@@ -85,12 +85,12 @@ repository:
   # Boolean
   boolean:
     name: constant.language.boolean.$1.json
-    match: '(?<=^|[,:\s\[])(true|false)(?=$|[,\s\]])'
+    match: '(?<=^|[,:\s\[])(true|false)(?=$|[,\s}\]])'
 
   # Null
   'null':
     name: constant.language.null.json
-    match: '(?<=^|[,:\s\[])null(?=$|[,\s\]])'
+    match: '(?<=^|[,:\s\[])null(?=$|[,\s}\]])'
 
   # Delimiter
   delimiters:


### PR DESCRIPTION
See the aforementioned issue for details.

Simple problem caused by a simple oversight, with an appropriately simple solution.