### PR TITLE
Change JSON delimiters to only highlight if valid

### DIFF
--- a/grammars/json.yaml-tmLanguage
+++ b/grammars/json.yaml-tmLanguage
@@ -96,9 +96,9 @@ repository:
   delimiters:
     patterns:
       - name: punctuation.separator.key-value.colon.json
-        match: ':'
+        match: '(?<=")\s*:'
       - name: punctuation.separator.comma.json
-        match: ','
+        match: ',\s*(?![}\]])'
 
   # Other/invalid
   invalid:

--- a/grammars/json.yaml-tmLanguage
+++ b/grammars/json.yaml-tmLanguage
@@ -98,7 +98,7 @@ repository:
       - name: punctuation.separator.key-value.colon.json
         match: '(?<=")\s*:'
       - name: punctuation.separator.comma.json
-        match: ',\s*(?![}\]])'
+        match: ',(?!\s*[}\]])'
 
   # Other/invalid
   invalid:

--- a/grammars/json.yaml-tmLanguage
+++ b/grammars/json.yaml-tmLanguage
@@ -59,7 +59,7 @@ repository:
   # Key:value pairs
   key:
     name: entity.name.tag.key.json
-    match: '(")((?:[^\\"]|\\.)*+)(")\s*(?=:)'
+    match: '(")((?:[^\\"]|\\.)*+)(")(?=\s*:)'
     captures:
       '1': { name: punctuation.definition.key.start.json }
       '2': { patterns: [ include: '#escapes' ] }
@@ -68,7 +68,7 @@ repository:
   # String
   string:
     name: string.quoted.double.json
-    match: '(")((?:[^\\"]|\\.)*+)(")\s*(?!:)'
+    match: '(")((?:[^\\"]|\\.)*+)(")(?!\s*:)'
     captures:
       '1': { name: punctuation.definition.string.begin.json }
       '2': { patterns: [ include: '#escapes' ] }

--- a/samples/readable.json
+++ b/samples/readable.json
@@ -1,4 +1,5 @@
 {
+    "item": {"trailing comma": true,},
     "lockfileVersion": 2,
     "packages": {
         "": {
@@ -20,5 +21,6 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         }
-    }
+    },
+    invalid: true
 }


### PR DESCRIPTION
- Relates to https://github.com/github/linguist/issues/5943

All instances of `:` and `,` were being highlighted as correct:
```json
{"bool": false, "with trailing comma though not valid json": null,}
```
![image](https://user-images.githubusercontent.com/42429413/174458186-1c4713f7-c580-473f-976e-1f1fd352a37e.png)

The standard JSON schema disallows trailing commas annoyingly.

There should be a simple check that it is not behind a closing bracket.

Trailing commas will now be marked invalid:
![image](https://user-images.githubusercontent.com/42429413/174458180-440e9d8a-3a19-41df-b80e-24342cb6ba52.png)

<sup>(Doing PRs for the JSON syntax because too many people use it for me to want to risk putting in a semibroken change lol..)</sup>