### PR TITLE
git-revlist: Fix trailing comments

### DIFF
--- a/grammars/git-revlist.yaml-tmLanguage
+++ b/grammars/git-revlist.yaml-tmLanguage
@@ -23,7 +23,7 @@ repository:
 
   sha:
     name: constant.numeric.sha.git-revlist
-    match: '[0-9a-fA-F]{40}(?=\s*$)'
+    match: '(?<=^\s*)[0-9a-fA-F]{40}(?=\s*(#.*)?$)'
 
   invalid:
     name: invalid.illegal.git-revlist

--- a/samples/.git-blame-ignore-revs
+++ b/samples/.git-blame-ignore-revs
@@ -1,6 +1,8 @@
 # 40-digit checksum (valid)
 1d92f4f73ed125bcd6912ae3ec804e405f4076a2
 
+1d92f4f73ed125bcd6912ae3ec804e405f4076a2 # trailing comment (valid)
+
 # 41-digit checksum (invalid)
 1d92f4f73ed125bcd6912ae3ec804e405f4076a20
 


### PR DESCRIPTION
Previously, trailing comments for git revlists were causing the line to be marked as invalid (as you can see from the diff from this very PR, since GitHub uses this project), even though it gets [parsed as expected](https://github.com/git/git/blob/e2067b49ecaef9b7f51a17ce251f9207f72ef52d/oidset.c#L73) by Git.

This PR fixes that, [here's](https://nixinova.github.io/NovaLightshow/?grammar-type=text&grammar=name%3A+Git+Revision+List%0AscopeName%3A+source.git-revlist%0AfileTypes%3A%0A-++git-blame-ignore-revs%0A-+.git-blame-ignore-revs%0Apatterns%3A%0A-+include%3A+%27%23main%27%0A%0Arepository%3A%0A++main%3A%0A++++patterns%3A%0A++++-+include%3A+%27%23comment%27%0A++++-+include%3A+%27%23sha%27%0A++++-+include%3A+%27%23invalid%27%0A%0A++comment%3A%0A++++name%3A+comment.line.number-sign.git-revlist%0A++++begin%3A+%27%23%27%0A++++end%3A+%27%24%27%0A++++beginCaptures%3A%0A++++++%270%27%3A%0A++++++++name%3A+punctuation.definition.comment.git-revlist%0A%0A++sha%3A%0A++++name%3A+constant.numeric.sha.git-revlist%0A++++match%3A+%27%28%3F%3C%3D%5E%5Cs*%29%5B0-9a-fA-F%5D%7B40%7D%28%3F%3D%5Cs*%28%23.*%29%3F%24%29%27%0A%0A++invalid%3A%0A++++name%3A+invalid.illegal.git-revlist%0A++++match%3A+%27%5CS.*%3F%28%3F%3D%5Cs*%24%29%27&sample-type=text&sample=%23+40-digit+checksum+%28valid%29%0A1d92f4f73ed125bcd6912ae3ec804e405f4076a2%0A%0A1d92f4f73ed125bcd6912ae3ec804e405f4076a2+%23+trailing+comment+%28valid%29%0A%0A%23+41-digit+checksum+%28invalid%29%0A1d92f4f73ed125bcd6912ae3ec804e405f4076a20%0A%0AInvalid+line+with+whitespace%0A%0A%0A%09%23+Indented%2C+40-digit+checksum+%28valid%29%0A%091d92f4f73ed125bcd6912ae3ec804e405f4076a2%0A%0A%09%23+Indented%2C+41-digit+checksum+%28invalid%29%0A%091d92f4f73ed125bcd6912ae3ec804e405f4076a20%0A%0A+++Indented%2C+invalid+line+with+whitespace+++) the result in the interactive view.

Cc @Alhadis because of https://github.com/Nixinova/NovaGrammars/pull/8

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles: